### PR TITLE
Removed non-existing document from event stream

### DIFF
--- a/test/M7A3.tml
+++ b/test/M7A3.tml
@@ -27,8 +27,5 @@ Bare document
 =VAL :Bare document
 -DOC ...
 +DOC
-=VAL :
--DOC ...
-+DOC
 =VAL "%!PS-Adobe-2.0 # Not the first line\n
 -DOC


### PR DESCRIPTION
There is no document between these two document end markers:

```
...
# No document
...
```

The spec allows multiple document end markers for the same document in [this production][1] (`l-document-suffix+`).

 [1]: http://www.yaml.org/spec/1.2/spec.html#l-yaml-stream