### PR TITLE
Use a program to generate the in-json automatically from test-event

### DIFF
--- a/test/2XXW.tml
+++ b/test/2XXW.tml
@@ -11,6 +11,13 @@ tags: spec mapping
 ? Sammy Sosa
 ? Ken Griff
 
++++ in-json
+{
+  "Ken Griff": null,
+  "Mark McGwire": null,
+  "Sammy Sosa": null
+}
+
 +++ out-yaml
 --- !!set
 Mark McGwire:

--- a/test/35KP.tml
+++ b/test/35KP.tml
@@ -12,6 +12,15 @@ tags: tag
 d
 e
 
++++ in-json
+{
+  "a": "b"
+}
+[
+  "c"
+]
+"d e"
+
 +++ out-yaml
 --- !!map
 a: b

--- a/test/6ZKB.tml
+++ b/test/6ZKB.tml
@@ -11,6 +11,13 @@ Document
 ---
 matches %: 20
 
++++ in-json
+"Document"
+null
+{
+  "matches %": 20
+}
+
 +++ test-event
 +STR
 +DOC

--- a/test/7Z25.tml
+++ b/test/7Z25.tml
@@ -8,6 +8,12 @@ scalar1
 ...
 key: value
 
++++ in-json
+"scalar1"
+{
+  "key": "value"
+}
+
 +++ out-yaml
 --- scalar1
 ...

--- a/test/8G76.tml
+++ b/test/8G76.tml
@@ -8,6 +8,8 @@ tags: spec comment empty scalar
 
 \
 
++++ in-json
+
 +++ out-yaml
 
 +++ test-event

--- a/test/98YD.tml
+++ b/test/98YD.tml
@@ -5,6 +5,8 @@ tags: spec comment empty
 +++ in-yaml
 \# Comment only.
 
++++ in-json
+
 +++ out-yaml
 
 +++ test-event

--- a/test/9DXL.tml
+++ b/test/9DXL.tml
@@ -11,6 +11,15 @@ Mapping: Document
 ---
 matches %: 20
 
++++ in-json
+{
+  "Mapping": "Document"
+}
+null
+{
+  "matches %": 20
+}
+
 +++ test-event
 +STR
 +DOC

--- a/test/9KAX.tml
+++ b/test/9KAX.tml
@@ -30,6 +30,25 @@ a6: 1
 !!str &a11
 value11
 
++++ in-json
+"scalar1"
+"scalar2"
+"scalar3"
+{
+  "key5": "value4"
+}
+{
+  "a6": 1,
+  "b6": 2
+}
+{
+  "key8": "value7"
+}
+{
+  "key10": "value9"
+}
+"value11"
+
 +++ out-yaml
 --- &a1 !!str scalar1
 --- &a2 !!str scalar2

--- a/test/AVM7.tml
+++ b/test/AVM7.tml
@@ -5,7 +5,6 @@ tags: edge
 +++ in-yaml
 
 +++ in-json
-null
 
 +++ test-event
 +STR

--- a/test/C4HZ.tml
+++ b/test/C4HZ.tml
@@ -18,6 +18,35 @@ tags: spec tag alias directive
   color: 0xFFEEBB
   text: Pretty vector drawing.
 
++++ in-json
+[
+  {
+    "center": {
+      "x": 73,
+      "y": 129
+    },
+    "radius": 7
+  },
+  {
+    "finish": {
+      "x": 89,
+      "y": 102
+    },
+    "start": {
+      "x": 73,
+      "y": 129
+    }
+  },
+  {
+    "color": 16772795,
+    "start": {
+      "x": 73,
+      "y": 129
+    },
+    "text": "Pretty vector drawing."
+  }
+]
+
 +++ out-yaml
 --- !<tag:clarkevans.com,2002:shape>
 - !<tag:clarkevans.com,2002:circle>

--- a/test/FQ7F.tml
+++ b/test/FQ7F.tml
@@ -24,3 +24,13 @@ tags: spec sequence
 -SEQ
 -DOC
 -STR
+
++++ lex-token
+SEQ-MARK 0 1 1 1
+WS-SPACE 1 1 1 2
+TEXT-VAL 2 12 1 3 :Mark McGwire
+WS-NEWLN 14 1 1 15
+SEQ-MARK 15 1 2 1
+WS-SPACE 1 1 1 2
+TEXT-VAL 2 12 1 3 :Sammy Sosa
+WS-NEWLN 14 1 1 15

--- a/test/JHB9.tml
+++ b/test/JHB9.tml
@@ -14,6 +14,17 @@ tags: spec header
 - Chicago Cubs
 - St Louis Cardinals
 
++++ in-json
+[
+  "Mark McGwire",
+  "Sammy Sosa",
+  "Ken Griffey"
+]
+[
+  "Chicago Cubs",
+  "St Louis Cardinals"
+]
+
 +++ out-yaml
 ---
 - Mark McGwire

--- a/test/KSS4.tml
+++ b/test/KSS4.tml
@@ -12,6 +12,10 @@ lines.
 string"
 --- &node foo
 
++++ in-json
+"quoted string"
+"foo"
+
 +++ out-yaml
 --- "quoted string"
 --- &node foo

--- a/test/M7A3.tml
+++ b/test/M7A3.tml
@@ -14,6 +14,10 @@ document
 # XXX literal needs indentation? libyaml sees a directive.
 \%!PS-Adobe-2.0 # Not the first line
 
++++ in-json
+"Bare document"
+"%!PS-Adobe-2.0 # Not the first line\n"
+
 +++ out-yaml
 Bare document
 ...

--- a/test/PUW8.tml
+++ b/test/PUW8.tml
@@ -7,6 +7,12 @@ tags: header
 a: b
 ---
 
++++ in-json
+{
+  "a": "b"
+}
+null
+
 +++ out-yaml
 ---
 a: b

--- a/test/RZT7.tml
+++ b/test/RZT7.tml
@@ -30,6 +30,35 @@ Stack:
     code: |-
       foo = bar
 
++++ in-json
+{
+  "Time": "2001-11-23 15:01:42 -5",
+  "User": "ed",
+  "Warning": "This is an error message for the log file"
+}
+{
+  "Time": "2001-11-23 15:02:31 -5",
+  "User": "ed",
+  "Warning": "A slightly different error message."
+}
+{
+  "Date": "2001-11-23 15:03:17 -5",
+  "Fatal": "Unknown variable \"bar\"",
+  "Stack": [
+    {
+      "code": "x = MoreObject(\"345\\n\")\n",
+      "file": "TopClass.py",
+      "line": 23
+    },
+    {
+      "code": "foo = bar",
+      "file": "MoreClass.py",
+      "line": 58
+    }
+  ],
+  "User": "ed"
+}
+
 +++ out-yaml
 ---
 Time: 2001-11-23 15:01:42 -5

--- a/test/U9NS.tml
+++ b/test/U9NS.tml
@@ -14,6 +14,18 @@ player: Sammy Sosa
 action: grand slam
 ...
 
++++ in-json
+{
+  "action": "strike (miss)",
+  "player": "Sammy Sosa",
+  "time": "20:03:20"
+}
+{
+  "action": "grand slam",
+  "player": "Sammy Sosa",
+  "time": "20:03:47"
+}
+
 +++ test-event
 +STR
 +DOC ---

--- a/test/UT92.tml
+++ b/test/UT92.tml
@@ -11,6 +11,12 @@ tags: spec header footer comment
 \# Empty
 ...
 
++++ in-json
+{
+  "matches %": 20
+}
+null
+
 +++ out-yaml
 ---
 matches %: 20

--- a/test/W4TN.tml
+++ b/test/W4TN.tml
@@ -12,6 +12,10 @@ tags: spec header footer 1.3-err
 \# Empty
 ...
 
++++ in-json
+"%!PS-Adobe-2.0\n"
+null
+
 +++ out-yaml
 --- |
   %!PS-Adobe-2.0

--- a/test/WZ62.tml
+++ b/test/WZ62.tml
@@ -8,6 +8,12 @@ tags: spec flow scalar
   !!str : bar,
 }
 
++++ in-json
+{
+  "": "bar",
+  "foo": ""
+}
+
 +++ out-yaml
 foo: !!str
 !!str: bar


### PR DESCRIPTION
Fixes issue #17.

I've left 2JQS there even though the YAML appears to be invalid, but there's only a single key in the JSON output.

All the JSON has been passed through jq for consistency, and sections arranged in consistent order.
JSON which would be derived from data with null keys or with binary tags has been omitted.
