### PR TITLE
Replace empty strings with nulls in JSON where actual value is !!null

### DIFF
--- a/test/4ABK.tml
+++ b/test/4ABK.tml
@@ -13,8 +13,8 @@ omitted value:,
 +++ in-json
 {
   "": "omitted key",
-  "http://foo.com": "",
-  "omitted value": "",
+  "http://foo.com": null,
+  "omitted value": null,
   "unquoted": "separate"
 }
 

--- a/test/FRK4.tml
+++ b/test/FRK4.tml
@@ -10,9 +10,8 @@ tags: spec flow scalar
 }
 
 +++ in-json
-# XXX Why are nulls spaces here?
 {
-  "foo": "",
+  "foo": null,
   "": "bar"
 }
 


### PR DESCRIPTION
A couple of the examples that are based on YAML 1.2 spec examples represent `!!null ""` values in JSON as `""` when they really should be `null`.