### PR TITLE
Remove incorrect block indentation indicator from 7T8X out-yaml

### DIFF
--- a/test/7T8X.tml
+++ b/test/7T8X.tml
@@ -24,7 +24,7 @@
 "\nfolded line\nnext line\n  * bullet\n\n  * list\n  * lines\n\nlast line\n"
 
 --- out-yaml
->2
+>
 
   folded line
 


### PR DESCRIPTION
The `2` indentation indicator is unnecessary, and therefore against the guideline given at least in the 1.2 version of the spec:
> It is always valid to specify an indentation indicator for a block scalar node, though a YAML processor should only emit an explicit indentation indicator for cases where detection will fail.

Furthermore, the `2` in this case doesn't even match the actual indentation of the contents. As "Document nodes are indented as if they have a parent indented at -1 spaces", and the example uses two spaces for indentation, the indicator here would need to be `3` for the in.yaml and out.yaml contents to match.