### PR TITLE
Fix WZ62 out.yaml

### DIFF
--- a/test/WZ62.tml
+++ b/test/WZ62.tml
@@ -10,7 +10,7 @@ tags: spec flow scalar
 
 +++ out-yaml
 foo: !!str
-!!str: bar
+!!str : bar
 
 +++ test-event
 +STR


### PR DESCRIPTION
The current production has `!!str: bar`, which does not match the intent -- `:` is a valid ns-tag-char, so that gets parsed as the value `bar` with a tag`!!str:`.

To fix, a space should be added before the `:`.