### PR TITLE
Open ended streams need document end marker

### DIFF
--- a/test/F8F9.tml
+++ b/test/F8F9.tml
@@ -30,13 +30,15 @@ keep: |+
   "keep": "# text\n\n"
 }
 
---- out-yaml(+)
+--- out-yaml
 strip: |-
   # text
 clip: |
   # text
 keep: |+
   # text
+
+...
 
 --- test-event
 +STR

--- a/test/K858.tml
+++ b/test/K858.tml
@@ -16,12 +16,14 @@ keep: |+
   "keep": "\n"
 }
 
---- out-yaml(+)
+--- out-yaml
 # XXX empty string should emit as ''
 strip: ""
 clip: ""
 # XXX why is libyaml emitting 2 (or literal at all)
 keep: |2+
+
+...
 
 --- test-event
 +STR


### PR DESCRIPTION
...like block scalars with the `|+` indicator for keeping trailing
empty lines

This document, if the last in the stream:
```
keep: |+
  line1


```
should be emitted as:
```
keep: |+
  line1


...
```
pyyaml and ruamel are doing this correctly (libyaml will do after the next release)

But there's room for discussion:
Arguably, this rule should also apply to all other documents in the stream, because a single document in a stream should be the same as the document alone.

But neither pyyaml nor ruamel currently output a `...` in this case:
```
keep: |+
  line1


--- doc two
```

I suggest to fix those two cases for now and discuss about the other use case then.