### PR TITLE
Disable test/G5U8.tml

### DIFF
--- a/test/G5U8.tml
+++ b/test/G5U8.tml
@@ -2,7 +2,7 @@
 --- from: @ingydotnet
 --- tags: flow sequence
 
---- in-yaml(<)
+--- in-yaml-xxx(<)
     ---
     - [-, -]
 

--- a/test/wip/G5U8.tml
+++ b/test/wip/G5U8.tml
@@ -1,8 +1,13 @@
 === Plain dashes in flow sequence
+
+--- note
+XXX This test turned out to be invalid 1.2.
+We are leaning towards making it valid in 1.3.
+
 --- from: @ingydotnet
 --- tags: flow sequence
 
---- in-yaml-xxx(<)
+--- in-yaml(<)
     ---
     - [-, -]
 


### PR DESCRIPTION
It's invalid in 1.2 according to spec review.

We want it to be valid in 1.3.

So we'll leave it here but disable.

When I generate the data with this, it removes `data/G5U8/in.yaml`.
Which is what we want I think.

