### PR TITLE
G5U8 is actually a 1.2 fail

### DIFF
--- a/src/G5U8.yaml
+++ b/src/G5U8.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Plain dashes in flow sequence
-  skip: true
   from: '@ingydotnet'
   tags: flow sequence
+  fail: true
   yaml: |
     ---
     - [-, -]
@@ -10,21 +10,4 @@
     +STR
      +DOC ---
       +SEQ
-       +SEQ
-        =VAL :-
-        =VAL :-
-       -SEQ
-      -SEQ
-     -DOC
-    -STR
-  json: |
-    [
-      [
-        "-",
-        "-"
-      ]
-    ]
-  dump: |
-    ---
-    - - '-'
-      - '-'
+       +SEQ []


### PR DESCRIPTION
https://play.yaml.io/main/parser?input=LS0tCi0gWy0sIC1dCg==

The ref parser says invalid but most others said valid, so I assumed the ref parser was wrong, and thus skipped this test until it was fixed.

But upon review the ref parser is correct, so unskipping this one now.